### PR TITLE
Run firebase serve, switch to getDownloadURL, cleanup company edit page

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "startupgnv-39bca"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+firebase-debug.log

--- a/firebase.json
+++ b/firebase.json
@@ -7,7 +7,8 @@
     "public": "public",
     "ignore": [
       "firebase.json",
-      "firebase.rules",
+      "firestore.rules",
+      "storage.rules",
       "firebase.indexes.json",
       "**/.*",
       "**/node_modules/**"
@@ -18,5 +19,8 @@
         "destination": "/index.html"
       }
     ]
+  },
+  "storage": {
+    "rules": "storage.rules"
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,22 @@
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  },
+  "hosting": {
+    "public": "public",
+    "ignore": [
+      "firebase.json",
+      "firebase.rules",
+      "firebase.indexes.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,20 @@
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if exists(/databases/$(database)/documents/admins/$(request.auth.token.email))
+    }
+    match /admins/{email} {
+      allow write: if false;
+      allow read: if request.auth.token.email == email;
+    }
+    match /companies/{document=**} {
+      allow read: if true;
+    }
+    match /jobs/{document=**} {
+      allow read: if true;
+    }
+    match /jobCategories/{document=**} {
+      allow read: if true;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@material-ui/icons": "^4.0.0",
     "@rehooks/window-size": "^1.0.2",
     "classnames": "^2.2.6",
-    "firebase": "^6.2.0",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.5",
     "polished": "^3.4.1",
@@ -22,8 +21,13 @@
     "react-select": "^3.0.4",
     "styled-components": "^4.1.3"
   },
+  "devDependencies": {
+    "npm-run-all": "^4.1.5"
+  },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "run-p -r start:cra start:firebase",
+    "start:firebase": "firebase serve",
+    "start:cra": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
@@ -52,5 +56,6 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  }
+  },
+  "proxy": "http://localhost:5000"
 }

--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,11 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script src="/__/firebase/6.3.1/firebase-app.js"></script>
+    <script src="/__/firebase/6.3.1/firebase-auth.js"></script>
+    <script src="/__/firebase/6.3.1/firebase-firestore.js"></script>
+    <script src="/__/firebase/6.3.1/firebase-storage.js"></script>
+    <script src="/__/firebase/init.js"></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/AdminCompaniesPage.js
+++ b/src/components/AdminCompaniesPage.js
@@ -10,7 +10,7 @@ import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 
 import { useAdminContainer } from './AdminPageContainer';
-import AdminListCard from './AdminListCard';
+import AdminCompanyListCard from './AdminCompanyListCard';
 import { db } from '../firebase';
 
 const useStyles = makeStyles({
@@ -54,12 +54,12 @@ export const AdminCompaniesPage = () => {
           </Grid>
           {companies
             .filter(({ name = '' }) => name.includes(search))
-            .map(({ name, id, coverImg, logoImg }) => (
+            .map(({ name, id, coverPath, logoPath }) => (
               <Grid key={id} item md={4} xs={12}>
-                <AdminListCard
+                <AdminCompanyListCard
                   key={id}
-                  coverSrc={coverImg}
-                  logoSrc={logoImg}
+                  coverPath={coverPath}
+                  logoPath={logoPath}
                   label={name}
                   linkTo={`/admin/companies/${id}/edit`}
                 />

--- a/src/components/AdminCompanyListCard.js
+++ b/src/components/AdminCompanyListCard.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { storage } from '../firebase';
+import { useDownloadURL } from 'react-firebase-hooks/storage';
+import AdminListCard from './AdminListCard';
+
+const AdminCompanyListCard = ({ coverPath, logoPath, ...cardProps }) => {
+  const [logoURL] = useDownloadURL(logoPath ? storage.ref(logoPath) : '');
+  const [coverURL] = useDownloadURL(coverPath ? storage.ref(coverPath) : '');
+  return <AdminListCard coverSrc={coverURL} logoSrc={logoURL} {...cardProps} />;
+};
+
+export default AdminCompanyListCard;

--- a/src/components/AdminLogin.js
+++ b/src/components/AdminLogin.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Redirect } from 'react-router-dom';
-import { auth } from '../firebase';
-import firebase from 'firebase/app';
+import firebase, { auth } from '../firebase';
 import { useAuthState } from 'react-firebase-hooks/auth';
 import { LinearProgress } from '@material-ui/core';
 
@@ -20,7 +19,7 @@ export const AdminLogin = ({
 
   const onClick = () => {
     const provider = new firebase.auth.GoogleAuthProvider();
-    firebase.auth().signInWithPopup(provider);
+    auth.signInWithPopup(provider);
   };
   return (
     <div>

--- a/src/components/CompanyListItem.js
+++ b/src/components/CompanyListItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 import { Link } from 'react-router-dom';
+import StorageImg from './StorageImg';
 
 const CompanyListItemContainer = styled.li`
   list-style-type: none;
@@ -46,13 +47,14 @@ const CompanyListItemContainer = styled.li`
 `;
 
 export const CompanyListItem = ({
-  company: { name, slug = '', logoImg = '' } = {},
-  company,
+  company: { name, slug = '', logoPath = '' } = {},
   showLogo = true
 }) => (
   <CompanyListItemContainer>
     <Link className="link-container" to={`/company/${slug}`}>
-      {showLogo && <img className="company-img" alt={name} src={logoImg} />}
+      {showLogo && (
+        <StorageImg className="company-img" alt={name} path={logoPath} />
+      )}
       <div className="info">
         <span className="name">{name}</span>
       </div>

--- a/src/components/JobListItem.js
+++ b/src/components/JobListItem.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components/macro';
 import { Link } from 'react-router-dom';
 import JobCategories from './JobCategories';
+import StorageImg from './StorageImg';
 
 const JobListItemContainer = styled.li`
   list-style-type: none;
@@ -84,10 +85,10 @@ export const JobListItem = ({
   <JobListItemContainer>
     <Link className="container-link" to={`/job/${id}`}>
       {showCompanyInfo && (
-        <img
+        <StorageImg
           className="company-img"
           alt={`${company.name}`}
-          src={company.logoImg}
+          path={company.logoPath}
         />
       )}
       <div className="info">

--- a/src/components/MapPageCompany.js
+++ b/src/components/MapPageCompany.js
@@ -39,8 +39,7 @@ const CompanyLink = styled.div`
 `;
 
 export const MapPageCompany = ({
-  history: { goBack },
-  company: { name, logoImg, coverImg = '', description = '', url = '' } = {},
+  company: { name, logoPath, coverPath = '', description = '', url = '' } = {},
   jobs = []
 }) => {
   if (!name) {
@@ -48,7 +47,7 @@ export const MapPageCompany = ({
   }
   return (
     <MapPageCompanyContainer>
-      <SidebarHeader coverImg={coverImg} mainImg={logoImg} />
+      <SidebarHeader coverPath={coverPath} logoPath={logoPath} />
       <div className="content">
         <h1 className="company-name">{name}</h1>
         <CompanyLink>

--- a/src/components/MapPageJob.js
+++ b/src/components/MapPageJob.js
@@ -111,8 +111,8 @@ export const MapPageJob = ({
   } = {},
   company: {
     name: companyName,
-    logoImg: companyLogo = '',
-    coverImg: companyCover = '',
+    logoPath: companyLogoPath = '',
+    coverPath: companyCoverPath = '',
     slug: companySlug
   } = {}
 }) => {
@@ -155,8 +155,8 @@ export const MapPageJob = ({
   return (
     <MapPageJobContainer showFullDesc={showFullDesc}>
       <SidebarHeader
-        coverImg={companyCover}
-        mainImg={companyLogo}
+        coverPath={companyCoverPath}
+        logoPath={companyLogoPath}
         height="120px"
         mainImgSize="80px"
       />

--- a/src/components/SidebarHeader.js
+++ b/src/components/SidebarHeader.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import styled from 'styled-components/macro';
+import StorageImg from './StorageImg';
+import { storage } from '../firebase';
+import { useDownloadURL } from 'react-firebase-hooks/storage';
 
 const SidebarHeaderContainer = styled.div`
   position: relative;
   height: ${({ height }) => height};
-  background-image: url(${props => props.coverImg});
+  background-image: url(${props => props.coverURL});
   background-size: cover;
   background-position: center;
 
@@ -21,18 +24,19 @@ const SidebarHeaderContainer = styled.div`
 `;
 
 export const SidebarHeader = ({
-  coverImg,
-  mainImg,
+  coverPath,
+  logoPath,
   height = '200px',
   mainImgSize = '120px'
 }) => {
+  const [coverURL] = useDownloadURL(coverPath ? storage.ref(coverPath) : '');
   return (
     <SidebarHeaderContainer
-      coverImg={coverImg}
+      coverURL={coverURL}
       height={height}
       mainImgSize={mainImgSize}
     >
-      <img className="logo" src={mainImg} alt="Logo" />
+      <StorageImg className="logo" path={logoPath} alt="Logo" />
     </SidebarHeaderContainer>
   );
 };

--- a/src/components/StorageImg.js
+++ b/src/components/StorageImg.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { storage } from '../firebase';
+import { useDownloadURL } from 'react-firebase-hooks/storage';
+
+const StorageImg = ({ path, ...imgProps }) => {
+  const [url] = useDownloadURL(path ? storage.ref(path) : '');
+  return <img src={url} {...imgProps} alt="" />;
+};
+
+export default StorageImg;

--- a/src/components/UploadAvatar.js
+++ b/src/components/UploadAvatar.js
@@ -25,7 +25,6 @@ export const UploadAvatar = ({
 }) => {
   const [progress, setProgress] = useState(0);
   const [imageReady, setImageReady] = useState(false);
-  const urlRef = useRef(storage.ref(`companyLogos/${companyID}`));
   const classes = useStyles({ size });
   const uploadRef = useRef();
   const uploadEl = uploadRef.current;
@@ -43,17 +42,10 @@ export const UploadAvatar = ({
     }
   }, [src]);
 
-  useEffect(() => {
-    urlRef.current
-      .getDownloadURL()
-      .then(onUploadComplete)
-      .catch(() => onUploadComplete(''));
-  }, [onUploadComplete]);
-
   const changeHandler = useCallback(() => {
     const file = uploadRef.current.files.item(0);
 
-    const task = urlRef.current.put(file);
+    const task = storage.ref(`companyLogos/${companyID}`).put(file);
     setProgress(0);
     setImageReady(false);
 
@@ -61,8 +53,8 @@ export const UploadAvatar = ({
       setProgress((snapshot.bytesTransferred / snapshot.totalBytes) * 100);
     });
 
-    task.then(() => urlRef.current.getDownloadURL()).then(onUploadComplete);
-  }, [onUploadComplete]);
+    task.then(({ ref }) => ref.fullPath).then(onUploadComplete);
+  }, [companyID, onUploadComplete]);
 
   useEffect(() => {
     if (uploadEl) {

--- a/src/components/UploadCoverImage.js
+++ b/src/components/UploadCoverImage.js
@@ -52,7 +52,7 @@ export const UploadCoverImage = ({
       setProgress((snapshot.bytesTransferred / snapshot.totalBytes) * 100);
     });
 
-    task.then(({ ref }) => ref.getDownloadURL()).then(onUploadComplete);
+    task.then(({ ref }) => ref.fullPath).then(onUploadComplete);
   }, [companyID, onUploadComplete]);
 
   useEffect(() => {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,8 +1,8 @@
-import firebase from 'firebase/app';
-import 'firebase/auth';
-import 'firebase/firestore';
-import 'firebase/storage';
-
+// import firebase from 'firebase/app';
+// import 'firebase/auth';
+// import 'firebase/firestore';
+// import 'firebase/storage';
+/*
 const config = {
   apiKey: process.env.REACT_APP_FIREBASE,
   authDomain: 'startupgnv-39bca.firebaseapp.com',
@@ -13,8 +13,18 @@ const config = {
 };
 
 firebase.initializeApp(config);
+
+// initialize firebase
+const s = document.createElement('script');
+s.type = 'text/javascript';
+s.src = '/__/firebase/init.js';
+document.head.appendChild(s);
+*/
+
+const firebase = window.firebase;
+
 export const db = firebase.firestore();
-db.enablePersistence();
+db.enablePersistence(); // enables offline data
 export const auth = firebase.auth();
 export const storage = firebase.storage();
 export default firebase;

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,26 +1,4 @@
-// import firebase from 'firebase/app';
-// import 'firebase/auth';
-// import 'firebase/firestore';
-// import 'firebase/storage';
-/*
-const config = {
-  apiKey: process.env.REACT_APP_FIREBASE,
-  authDomain: 'startupgnv-39bca.firebaseapp.com',
-  databaseURL: 'https://startupgnv-39bca.firebaseio.com',
-  projectId: 'startupgnv-39bca',
-  storageBucket: 'startupgnv-39bca.appspot.com',
-  messagingSenderId: '585426519184'
-};
-
-firebase.initializeApp(config);
-
-// initialize firebase
-const s = document.createElement('script');
-s.type = 'text/javascript';
-s.src = '/__/firebase/init.js';
-document.head.appendChild(s);
-*/
-
+// firebase is loaded in the index.html page
 const firebase = window.firebase;
 
 export const db = firebase.firestore();

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,14 @@
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      // ideally we'd use:
+    	// allow write: if exists(/databases/$(database)/documents/admins/$(request.auth.token.email));
+    	// but we can't currently since storage can't lookup in firestore
+      allow write: if request.auth.token.email == "james@getadmiral.com";
+      allow write: if request.auth.token.email == "nathan@getadmiral.com";
+      allow write: if request.auth.token.email == "will@getadmiral.com";
+      allow read: if true;
+    }
+  }
+}
+  


### PR DESCRIPTION
In order for us to start using Firebase functions (which the importer will
use we need to start using Firebase serve). I set this up so npm start will
run both serve and start.

We were storing getDownloadURL but that URL contains a token that can be
revoked and changed. So instead I'm storing the path in firestore and then
calling getDownloadURL at runtime. I didn't reupload everyone's images yet
because I wanted to make sure everyone was okay with this change.

I cleaned up the admin company edit page since it wasn't using hooks for
everything but the AdminCompanyPage also lets you upload and looks nicer
so maybe we should move the edit page into the normal page?