### PR TITLE
Add company card to job page

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -18,7 +18,7 @@ import CompaniesPage from './CompaniesPage';
 import CompanyPage from './CompanyPage';
 import AboutPage from './AboutPage';
 import EcosystemPage from './EcosystemPage';
-import JobPage from './JobPage';
+import JobPage from './Job/JobPage';
 import JobsPage from './JobsPage';
 import NewToGainesvillePage from './NewToGainesvillePage';
 import AddCompanyPage from './AddCompanyPage';

--- a/src/components/CompanyPage.js
+++ b/src/components/CompanyPage.js
@@ -3,7 +3,7 @@ import styled from 'styled-components/macro';
 import { db } from '../firebase';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import AppContext from './AppContext';
-import SidebarHeader from './SidebarHeader';
+import Header from './Job/Header';
 import JobList from './JobList';
 import Error from './Error';
 import MapContainer from './MapContainer';
@@ -109,7 +109,7 @@ export const CompanyPage = ({
         <meta property="og:type" content="website" />
       </Helmet>
       <CompanyPageContainer>
-        <SidebarHeader title={name} coverPath={coverPath} logoPath={logoPath}>
+        <Header title={name} coverPath={coverPath} logoPath={logoPath}>
           {employeeCount && (
             <EmployeeCount>
               <span>{`${employeeCount} Employees`}</span>
@@ -121,7 +121,7 @@ export const CompanyPage = ({
               Open Website
             </a>
           </CompanyLink>
-        </SidebarHeader>
+        </Header>
         <CompanyContent>
           <p className="description">{description}</p>
           {companyJobs && companyJobs.length > 0 && (

--- a/src/components/Job/ApplyBtn.js
+++ b/src/components/Job/ApplyBtn.js
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import styled from 'styled-components/macro';
-import TextInput from './TextInput';
-import Button from './Button';
+import TextInput from '../TextInput';
+import Button from '../Button';
 
-import { db } from '../firebase';
+import { db } from '../../firebase';
 
-const ApplyContainer = styled.div`
+const Container = styled.div`
   .apply-btn {
     margin: 0 0 10px 0;
   }
@@ -39,7 +39,7 @@ const ApplyContainer = styled.div`
   }
 `;
 
-const JobApply = ({ job, job: { applyUrl, id } = {}, companyName = '' }) => {
+const ApplyBtn = ({ job, job: { applyUrl, id } = {}, companyName = '' }) => {
   const [showForm, setShowForm] = useState(false);
   const [applicantEmail, setApplicantEmail] = useState('');
   const [submitState, setSubmitState] = useState({
@@ -47,6 +47,7 @@ const JobApply = ({ job, job: { applyUrl, id } = {}, companyName = '' }) => {
     error: false,
     success: false
   });
+
   const onApplyClick = () => {
     // setShowForm(true);
     window.ga('send', {
@@ -57,6 +58,7 @@ const JobApply = ({ job, job: { applyUrl, id } = {}, companyName = '' }) => {
     });
     window.open(applyUrl);
   };
+
   const onFormSubmit = e => {
     e.preventDefault();
     setSubmitState({ submitting: true, error: false, success: false });
@@ -77,6 +79,7 @@ const JobApply = ({ job, job: { applyUrl, id } = {}, companyName = '' }) => {
     }, 2000);
     return false;
   };
+
   let content;
   if (submitState.success) {
     content = <p>Success! Taking you to the job application...</p>;
@@ -109,7 +112,8 @@ const JobApply = ({ job, job: { applyUrl, id } = {}, companyName = '' }) => {
       />
     );
   }
-  return <ApplyContainer>{content}</ApplyContainer>;
+
+  return <Container>{content}</Container>;
 };
 
-export default JobApply;
+export default ApplyBtn;

--- a/src/components/Job/CompanyCard.js
+++ b/src/components/Job/CompanyCard.js
@@ -1,0 +1,83 @@
+import React, { useContext } from 'react';
+import styled from 'styled-components';
+import { device } from '../device';
+import StorageImg from '../StorageImg';
+import { Link } from 'react-router-dom';
+
+const Card = styled.div`
+  margin-bottom: 30px;
+  border-radius: 3px;
+  overflow: hidden;
+  box-shadow: 3px 0 13px 0 rgba(0, 0, 0, 0.08);
+  transition: 200ms;
+  cursor: pointer;
+  background: white;
+
+  &:hover {
+    box-shadow: 3px 0 13px 0 rgba(0, 0, 0, 0.15);
+    transform: scale(1.01);
+    transform-origin: center;
+  }
+
+  @media ${device.tabletPort} {
+    display: flex;
+    flex-flow: row nowrap;
+    height: 160px;
+  }
+`;
+
+const Thumbnail = styled.div`
+  height: 100%;
+
+  @media ${device.tabletPort} {
+    min-width: 160px;
+  }
+`;
+
+const Content = styled.div`
+  padding: 25px;
+`;
+
+const Name = styled.h4`
+  font-family: WilliamsCaslonText, serif;
+  font-size: 18px;
+  color: #131516;
+  margin-bottom: 3px;
+`;
+
+const Count = styled.h5`
+  font-family: WilliamsCaslonText, serif;
+  font-size: 16px;
+  color: #a3a9b3;
+`;
+
+const Summary = styled.p`
+  font-family: WilliamsCaslonText, serif;
+  font-size: 16px;
+  color: #131516;
+  line-height: 1.2rem;
+  margin-top: 5px;
+`;
+
+const CompanyCard = ({ name, logo, employeeCount, summary, slug }) => {
+  return (
+    <Link style={{ textDecoration: 'none' }} to={'/companies/' + slug}>
+      <Card>
+        <Thumbnail>
+          <StorageImg
+            alt="Company Logo"
+            path={logo}
+            style={{ objectFit: 'cover', height: '100%', width: '100%' }}
+          />
+        </Thumbnail>
+        <Content>
+          <Name>{name}</Name>
+          <Count>{employeeCount} Employees</Count>
+          <Summary>{summary}</Summary>
+        </Content>
+      </Card>
+    </Link>
+  );
+};
+
+export default CompanyCard;

--- a/src/components/Job/Header.js
+++ b/src/components/Job/Header.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import styled from 'styled-components/macro';
-import StorageImg from './StorageImg';
-import { storage } from '../firebase';
+import StorageImg from '../StorageImg';
+import { storage } from '../../firebase';
 import { useDownloadURL } from 'react-firebase-hooks/storage';
 
-const SidebarHeaderContainer = styled.div`
+const Container = styled.div`
   position: relative;
   background-image: linear-gradient(
       0deg,
@@ -36,12 +36,12 @@ const HeaderInner = styled.div`
 
 const Title = styled.h1`
   position: absolute;
-  left: ${({ mainImgSize }) => mainImgSize + 50}px;
   bottom: 10px;
   color: white;
   text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.3);
   font-family: 'Montserrat', sans-serif;
   font-size: 36px;
+  padding-left: 30px;
 `;
 
 const HeaderContent = styled.div`
@@ -51,11 +51,11 @@ const HeaderContent = styled.div`
 const ContentInner = styled.div`
   max-width: ${({ theme }) => theme.contentMaxWidth};
   margin: 0 auto;
-  padding: 10px 20px 10px ${({ mainImgSize }) => mainImgSize + 50}px;
+  padding: 10px 30px;
   box-sizing: border-box;
 `;
 
-export const SidebarHeader = ({
+export const Header = ({
   title = '',
   coverPath,
   logoPath,
@@ -65,18 +65,17 @@ export const SidebarHeader = ({
 }) => {
   const [coverURL] = useDownloadURL(coverPath ? storage.ref(coverPath) : '');
   return (
-    <SidebarHeaderContainer coverURL={coverURL} mainImgSize={mainImgSize}>
+    <Container coverURL={coverURL} mainImgSize={mainImgSize}>
       <HeaderInner coverHeight={coverHeight}>
         {title && <Title mainImgSize={mainImgSize}>{title}</Title>}
-        <StorageImg className="logo" path={logoPath} alt="Logo" />
       </HeaderInner>
       {children && (
         <HeaderContent>
           <ContentInner mainImgSize={mainImgSize}>{children}</ContentInner>
         </HeaderContent>
       )}
-    </SidebarHeaderContainer>
+    </Container>
   );
 };
 
-export default SidebarHeader;
+export default Header;

--- a/src/components/Job/JobCategories.js
+++ b/src/components/Job/JobCategories.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React, { useContext } from 'react';
-import AppContext from './AppContext';
-import Tags from './Tags';
+import AppContext from '../AppContext';
+import Tags from '../Tags';
 
 const JobCategories = ({
   categories,

--- a/src/components/Job/JobPage.js
+++ b/src/components/Job/JobPage.js
@@ -1,22 +1,22 @@
 import _ from 'lodash';
 import React, { useContext } from 'react';
-import { baseContentStyling } from './mixins';
+import { baseContentStyling } from '../mixins';
 import BusinessIcon from '@material-ui/icons/Business';
 import styled from 'styled-components/macro';
-import AppContext from './AppContext';
-import SidebarHeader from './SidebarHeader';
+import AppContext from '../AppContext';
+import Header from './Header';
 import { Link, Redirect } from 'react-router-dom';
 import JobCategories from './JobCategories';
-
-import JobApply from './JobApply';
-
+import ApplyBtn from './ApplyBtn';
 import { LinearProgress } from '@material-ui/core';
 import { Parser } from 'html-to-react';
 import { Helmet } from 'react-helmet';
+import CompanyCard from './CompanyCard';
+import { device } from '../device';
 
 const htmlParser = new Parser();
 
-const MapPageJobContainer = styled.div`
+const Container = styled.div`
   background: ${({ theme }) => theme.uiBackground};
 
   .company-name {
@@ -41,23 +41,32 @@ const MapPageJobContainer = styled.div`
   }
 `;
 
-const JobMainContent = styled.div`
+const Main = styled.div`
   display: flex;
   max-width: ${({ theme }) => theme.contentMaxWidth};
   margin: 0 auto;
   padding: 30px 0 0 0;
+
+  @media ${device.tabletPort}, ${device.mobile} {
+    flex-flow: column nowrap;
+  }
 `;
 
-const JobContent = styled.div`
+const ContentContainer = styled.div`
   flex: 5;
   padding: 0 30px 20px;
 `;
 
-const JobSidebar = styled.div`
+const Sidebar = styled.div`
   flex: 2;
+
+  @media ${device.tabletPort}, ${device.mobile} {
+    padding-left: 30px;
+    padding-right: 30px;
+  }
 `;
 
-const JobDescription = styled.div`
+const Description = styled.div`
   ${baseContentStyling()}
 `;
 
@@ -65,8 +74,7 @@ const CategoriesContainer = styled.div`
   display: inline-block;
 `;
 
-export const MapPageJob = ({
-  history: { goBack },
+export const JobPage = ({
   match: {
     params: { jobID }
   }
@@ -90,7 +98,9 @@ export const MapPageJob = ({
     name: companyName,
     logoPath: companyLogoPath = '',
     coverPath: companyCoverPath = '',
-    slug: companySlug
+    slug: companySlug,
+    employeeCount: companyEmployeeCount,
+    shortDescription: companyShortDescription
   } = _.find(companies, { id: companyID });
 
   if (!jobTitle) {
@@ -110,8 +120,9 @@ export const MapPageJob = ({
         />
         <meta property="og:type" content="website" />
       </Helmet>
-      <MapPageJobContainer>
-        <SidebarHeader
+
+      <Container>
+        <Header
           coverPath={companyCoverPath}
           logoPath={companyLogoPath}
           coverHeight={160}
@@ -127,18 +138,27 @@ export const MapPageJob = ({
               <JobCategories categories={categories} />
             </CategoriesContainer>
           )}
-        </SidebarHeader>
-        <JobMainContent>
-          <JobContent>
-            <JobDescription>{htmlParser.parse(jobDescription)}</JobDescription>
-          </JobContent>
-          <JobSidebar>
-            <JobApply job={job} companyName={companyName} />
-          </JobSidebar>
-        </JobMainContent>
-      </MapPageJobContainer>
+        </Header>
+
+        <Main>
+          <ContentContainer>
+            <Description>{htmlParser.parse(jobDescription)}</Description>
+          </ContentContainer>
+
+          <Sidebar>
+            <ApplyBtn job={job} companyName={companyName} />
+            <CompanyCard
+              name={companyName}
+              logo={companyLogoPath}
+              employeeCount={companyEmployeeCount}
+              summary={companyShortDescription}
+              slug={companySlug}
+            />
+          </Sidebar>
+        </Main>
+      </Container>
     </>
   );
 };
 
-export default MapPageJob;
+export default JobPage;

--- a/src/components/JobListItemLarge.js
+++ b/src/components/JobListItemLarge.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { storage } from '../firebase';
 import { useDownloadURL } from 'react-firebase-hooks/storage';
 import StorageImg from './StorageImg';
-import JobCategories from './JobCategories';
+import JobCategories from './Job/JobCategories';
 
 const ItemContainer = styled.div`
   height: 140px;
@@ -56,7 +56,7 @@ const LogoContainer = styled.div`
   width: 140px;
   height: 140px;
   margin-right: 20px;
-  justify-content: center
+  justify-content: center;
   align-items: center;
   background: url(${({ bgImg }) => bgImg});
   background-size: cover;
@@ -75,7 +75,7 @@ const LogoContainer = styled.div`
 const JobInfo = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center
+  justify-content: center;
   align-items: center;
 
   @media ${device.tabletPort}, ${device.mobile} {


### PR DESCRIPTION
This adds a linkable company card component to each job posting that links out to a respective companies page. This card is formatted to fit all screen sizes, although there are other parts of the page that currently aren't (I figured that was outside the scope of this particular item).

Additionally, most of the job page components are now consolidated into a `Job` folder.