### PR TITLE
Added progress scroll bar to jobs page

### DIFF
--- a/src/components/Jobs/JobsPage.js
+++ b/src/components/Jobs/JobsPage.js
@@ -8,6 +8,7 @@ import heroBG from '../../assets/images/jobs-hero.jpg';
 import { Helmet } from 'react-helmet';
 
 import { LinearProgress } from '@material-ui/core';
+import ProgressBar from '../UI/ProgressBar';
 
 const JobsPageContent = styled.div`
   max-width: ${({ theme }) => theme.contentMaxWidth};
@@ -60,6 +61,8 @@ export const JobsPage = () => {
         />
         <meta property="og:type" content="website" />
       </Helmet>
+
+      <ProgressBar />
 
       <Hero bgImage={heroBG} title="Available Positions" size="medium" />
       <JobsPageContent>

--- a/src/components/UI/ProgressBar.js
+++ b/src/components/UI/ProgressBar.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Bar = styled.div`
+  position: fixed;
+  top: 0;
+  background: linear-gradient(
+    to right,
+    rgba(0, 180, 150, 1) ${props => props.completePct},
+    transparent 0
+  );
+  width: 100%;
+  height: 4px;
+  z-index: 3;
+`;
+
+const ProgressBar = () => {
+  const [scroll, setScroll] = React.useState(0);
+
+  const calculateScrollDistance = () => {
+    const scrollTop = window.pageYOffset; // how much the user has scrolled by
+    const winHeight = window.innerHeight;
+    const docHeight = Math.max(
+      document.body.scrollHeight,
+      document.documentElement.scrollHeight,
+      document.body.offsetHeight,
+      document.documentElement.offsetHeight,
+      document.body.clientHeight,
+      document.documentElement.clientHeight
+    );
+
+    const totalDocScrollLength = docHeight - winHeight;
+    const scrollPosition = Math.floor((scrollTop / totalDocScrollLength) * 100);
+
+    setScroll(scrollPosition);
+  };
+
+  const onScroll = () => {
+    document.addEventListener('scroll', () => {
+      requestAnimationFrame(() => {
+        calculateScrollDistance();
+      });
+    });
+  };
+
+  React.useEffect(() => {
+    onScroll();
+  }, []);
+
+  return <Bar completePct={`${scroll}%`} />;
+};
+
+export default ProgressBar;


### PR DESCRIPTION
This adds a thin, horizontal ribbon to the top of the jobs page to indicate to the user how deep into the list of jobs they have scrolled.

This is implemented though a simple reusable progress bar component that can be dropped into any page for a similar effect if needed.