### PR TITLE
Added company listing image option

### DIFF
--- a/src/components/AdminCompaniesPage.js
+++ b/src/components/AdminCompaniesPage.js
@@ -83,7 +83,7 @@ export const AdminCompaniesPage = () => {
               <Grid key={id} item md={4} xs={12}>
                 <AdminListCard
                   key={id}
-                  coverPath={coverPath}
+                  coverPath={coverPath.replace('Cover', 'Listing')}
                   logoPath={logoPath}
                   label={name}
                   linkTo={`/admin/companies/${id}/edit`}

--- a/src/components/AdminPage.js
+++ b/src/components/AdminPage.js
@@ -5,7 +5,7 @@ import AdminCompanyPage from './AdminCompanyPage';
 import AdminCompaniesPage from './AdminCompaniesPage';
 import AdminIndex from './AdminIndex';
 import AdminJobsPage from './AdminJobsPage';
-import AdminEditCompanyPage from './AdminEditCompanyPage';
+import EditPage from './Admin/Company/EditPage';
 import AdminJobPage from './AdminJobPage';
 import EcosystemPage from './Admin/Ecosystem';
 import AdminPageContainer from './AdminPageContainer';
@@ -17,15 +17,11 @@ export const AdminPage = () => (
     <CssBaseline />
     <Switch>
       <Route exact path="/admin/companies" component={AdminCompaniesPage} />
-      <Route
-        exact
-        path="/admin/companies/new"
-        component={AdminEditCompanyPage}
-      />
+      <Route exact path="/admin/companies/new" component={EditPage} />
       <Route
         exact
         path="/admin/companies/:companyID/edit"
-        component={AdminEditCompanyPage}
+        component={EditPage}
       />
       <Route
         exact

--- a/src/components/Companies/CompanyListItemLarge.js
+++ b/src/components/Companies/CompanyListItemLarge.js
@@ -120,7 +120,9 @@ const CompanyListItemLarge = ({
   return (
     <ItemContainer onMouseEnter={onMouseEnter}>
       <Link className="container-link" to={'/companies/' + slug}>
-        <Images coverImg={coverUrl}>
+        <Images
+          coverImg={coverUrl ? coverUrl.replace('Cover', 'Listing') : coverUrl}
+        >
           <StorageImg className="logo" alt={name} path={logoPath} />
         </Images>
         <CompanyInfo>


### PR DESCRIPTION
This add a "Listing" image option to companies in the admin panel. An image's listing image will be displayed as their background in the admin portal, and their background image in the companies page of the client. The companies cover page will now only be displayed in a specific company page (as the header background), and as the long image in the featured company/job list on the home page.

Currently, all companies have the same listing and cover images. I created a new folder in Firebase (`companyListings`) specifically for listing images, and copied over all the existing cover images.

Lastly, I also updated the image spec requirements in Notion, however it was my best estimate so feel free to make any edits if you catch anything.